### PR TITLE
1.4.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,7 @@
                 "--verbosity=diagnostic",
                 "--rootDir=${workspaceRoot}",
                 "--Target=Info",
+                "--TestSourceLink=false",
                 "--Header=\"-+++++++-,MicroElements,DevOps,-+++++++-\""
             ],
             "cwd": "${workspaceRoot}",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-# 1.4.0 - beta
-- Added: SetEmptyValues for ScriptParam to treat values as NoValue
+# 1.4.0
+- Added: `SetEmptyValues` for ScriptParam to treat some values as NoValue
+- Changed: `TestSourceLink` option value is true for CI servers because local builds are often not committed.
+- Fixed: Bug "Default value for ParamValue treats as NoValue"
 
 # 1.3.0
 - Added: `CodeCoverage` task

--- a/MicroElements.DevOps.nuspec
+++ b/MicroElements.DevOps.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>MicroElements.DevOps</id>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
     <description>$description$</description>
     <authors>alexey.petriashev</authors>
     <projectUrl>https://github.com/micro-elements/MicroElements.DevOps</projectUrl>

--- a/resources/build.ps1
+++ b/resources/build.ps1
@@ -22,7 +22,7 @@ if(!$PSScriptRoot){
 
 $CAKE_VERSION = "0.29.0"
 $CAKE_BAKERY_VERSION = "0.3.0"
-$DEVOPS_VERSION = "1.3.0"
+$DEVOPS_VERSION = "1.4.0"
 $NUGET_URL = "https://api.nuget.org/v3/index.json"
 $NUGET_BETA_URL = "https://www.myget.org/F/micro-elements/api/v3/index.json"
 #$NUGET_URL = "file://C:\NuGet"

--- a/resources/build.sh
+++ b/resources/build.sh
@@ -7,7 +7,7 @@
 echo "Starting build.sh"
 
 CAKE_VERSION=0.29.0
-DEVOPS_VERSION=1.3.0
+DEVOPS_VERSION=1.4.0
 NUGET_URL=https://api.nuget.org/v3/index.json
 NUGET_BETA_URL=https://www.myget.org/F/micro-elements/api/v3/index.json
 

--- a/scripts/common.cake
+++ b/scripts/common.cake
@@ -20,7 +20,7 @@ using System.Reflection;
 /// Converts value to ParamValue.
 /// </summary>
 public static ParamValue<T> ToParamValue<T>(this T value, ParamSource source = ParamSource.Conventions)
-    => !Equals(value, default(T)) ? new ParamValue<T>(value, source) : ParamValue<T>.NoValue;
+    => new ParamValue<T>(value, source);
 
 public static Type CakeGlobalType() => typeof(ScriptArgs).DeclaringType.GetTypeInfo();
 

--- a/scripts/conventions.cake
+++ b/scripts/conventions.cake
@@ -64,7 +64,9 @@ public static ScriptArgs UseDefaultConventions(this ScriptArgs args)
     context.Information($"VERSION: {args.Version.VersionPrefix}");
 
     args.UseSourceLink.SetDefaultValue(true).Build(args);
-    args.TestSourceLink.SetDefaultValue(true).Build(args);
+
+    // TestSourceLink on CI servers because local builds are often not committed.
+    args.TestSourceLink.SetValue(a=>!a.Context.BuildSystem().IsLocalBuild).Build(args);
 
     return args;
 }


### PR DESCRIPTION
- Added: `SetEmptyValues` for ScriptParam to treat some values as NoValue
- Changed: `TestSourceLink` option value is true for CI servers because local builds are often not committed.
- Fixed: Bug "Default value for ParamValue treats as NoValue"